### PR TITLE
v0.56.1

### DIFF
--- a/otelbuilder/Makefile
+++ b/otelbuilder/Makefile
@@ -88,7 +88,7 @@ otelcol-logzio-all-sys: otelcol-logzio-darwin_amd64 otelcol-logzio-linux_amd64 o
 
 .PHONY: otelcol-logzio-darwin_amd64
 otelcol-logzio-darwin_amd64:
-	GOOS=darwin  GOARCH=amd64 $(MAKE) build BINARY_NAME=$(BINARY_NAME)-darwin_amd64
+	CGO_ENABLED=1 GOOS=darwin  GOARCH=amd64 $(MAKE) build BINARY_NAME=$(BINARY_NAME)-darwin_amd64
 
 .PHONY: otelcol-logzio-linux_amd64
 otelcol-logzio-linux_amd64:


### PR DESCRIPTION
- Add `CGO_ENABLED=1` for darwin amd build, this flag enables CPU and disk metrics with `hostmetrics` receiver on mac machines https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#notes